### PR TITLE
Add sinon spy example to readme

### DIFF
--- a/packages/sui-studio-utils/README.md
+++ b/packages/sui-studio-utils/README.md
@@ -75,6 +75,48 @@ domain.get('current_user_use_case').execute().then((products) => {
 })
 ```
 
+### Using Sinon spies for testing
+
+> You can use Sinon spies to test that your use cases are being called correctly and verify their behavior. This is particularly useful when you want to mock a response while also tracking how the function was called.
+
+```js
+import { DomainBuilder } from '@s-ui/studio-tools'
+import sinon from 'sinon'
+import myDomain from 'domain'
+
+// Create a spy that returns a specific response
+const spy = sinon.spy(() => {
+  return 'spied-response'
+})
+
+// Build the domain with the spied use case
+const domain = DomainBuilder
+  .extend({ domain: myDomain })
+  .for({ useCase: 'get_products' })
+  .respondWith({ success: spy })
+  .build()
+
+// Execute the use case
+domain.get('get_products').execute().then((result) => {
+  console.log(result) // 'spied-response'
+  
+  // Verify the spy was called
+  sinon.assert.calledOnce(spy)
+  
+  // You can also check call arguments, call count, etc.
+  console.log(spy.callCount) // 1
+  console.log(spy.firstCall.args) // Arguments passed to the spy
+})
+```
+
+This approach allows you to:
+- Track how many times a use case was called
+- Verify the arguments passed to the use case
+- Assert on the call order when multiple use cases are involved
+- Combine mocking with behavior verification in your tests
+
+For a complete example, see the [test implementation](https://github.com/SUI-Components/sui/blob/main/packages/sui-studio-utils/src/test/common/domainBuilderSpec.js).
+
 
 
 > THINGS TO KEEP IN MIND: 


### PR DESCRIPTION
## Description
Adds a new section to the `sui-studio-utils` README to document how to use Sinon spies with `DomainBuilder` for testing use cases. This provides a clear reference for developers to track use case calls, verify arguments, and combine mocking with behavior verification.

## Related Issue
Relates to #1779 (specifically commit `5c572ba10d802209b32c2e6d7ac9911f7ee65d69`)

## Example
```js
import { DomainBuilder } from '@s-ui/studio-tools'
import sinon from 'sinon'
import myDomain from 'domain'

const spy = sinon.spy(() => 'spied-response')

const domain = DomainBuilder
  .extend({ domain: myDomain })
  .for({ useCase: 'get_products' })
  .respondWith({ success: spy })
  .build()

domain.get('get_products').execute().then((result) => {
  console.log(result) // 'spied-response'
  sinon.assert.calledOnce(spy)
})
```

---
<a href="https://cursor.com/background-agent?bcId=bc-84770c9b-4ae1-4d67-b504-3a31f9409b34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-84770c9b-4ae1-4d67-b504-3a31f9409b34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

